### PR TITLE
Style fringes

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -44,9 +44,8 @@ legend {
 }
 
 .error-message {
-  font-size: 1.1rem;
+  font-size: 1.3rem;
   line-height: 1.3;
-  font-style: italic;
   color: #e31c3d;
 }
 

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -243,10 +243,6 @@ td input[type="checkbox"] + label {
   font-weight: $font-bold;
 }
 
-.form_group-rate {
-  clear: both;
-}
-
 .form_group-rate-item {
   clear: none;
   float: left;
@@ -262,6 +258,11 @@ td input[type="checkbox"] + label {
 .form_group-rate-fringe {
   margin-left: 2rem;
   width: 12rem;
+}
+
+.form_group-rate-fringe-hourly {
+  clear: both;
+  margin-left: 0;
 }
 
 .label-straight {

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -302,6 +302,10 @@ input[type=number]::-webkit-outer-spin-button {
 
 .add_overtime {
   margin-top: 1em;
+
+  &:hover {
+    cursor: pointer;
+  }
 }
 
 .fieldset-inputs-owner {

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -302,11 +302,14 @@ input[type=number]::-webkit-outer-spin-button {
 
 .add_overtime {
   margin-top: 1em;
+}
 
+.add-link {
   &:hover {
     cursor: pointer;
   }
 }
+
 
 .fieldset-inputs-owner {
   padding-bottom: 1.5em;

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -38,15 +38,15 @@ legend {
   }
 }
 
-.error {
-  background-color: #f9dede;
-  box-shadow: 0 0 3px #e31c3d, 0 0 7px #e31c3d;
+input.error {
+  border: 3px solid $color-secondary-dark;
 }
 
 .error-message {
-  font-size: 1.3rem;
+  font-size: 1.4rem;
+  font-weight: $font-bold;
   line-height: 1.3;
-  color: #e31c3d;
+  color: $color-secondary-dark;
 }
 
 .usa-font-lead {

--- a/js/main.js
+++ b/js/main.js
@@ -125,7 +125,7 @@ var setup = {
       setup.straightRate = this.value;
       if (parseInt(this.value) < dbRate) {
         this.classList.add('error');
-        this.parentElement.querySelector('.error-message').innerHTML = "This rate is below the minimum required by Davis-Bacon.";
+        this.parentElement.querySelector('.error-message').innerHTML = "The rate of pay is less than the the prevailing wage.";
       } else {
         this.classList.remove('error');
         this.parentElement.querySelector('.error-message').innerHTML = "";

--- a/pages/edit-employee-details.html
+++ b/pages/edit-employee-details.html
@@ -23,7 +23,7 @@ permalink: /edit-employee-details/
     </div>
     <div class="optional-info">
       <label for="custom-classification" class="slide-down-handler">
-        <a id="add-classification">+ Add custom work classification</a>
+        <a class="add-link" id="add-classification">+ Add custom work classification</a>
       </label>
       <div class="slide-down-content">
         <input id="custom-classification" name="input-type-text" type="text">

--- a/pages/enter-employee-details.html
+++ b/pages/enter-employee-details.html
@@ -27,7 +27,7 @@ permalink: /enter-employee-details/
     </div>
     <div class="optional-info" data-height="200">
       <label for="custom-classification" class="slide-down-handler">
-        <a id="add-classification">+ Add custom work classification</a>
+        <a class="add-link" id="add-classification">+ Add custom work classification</a>
       </label>
       <div class="slide-down-content">
         <input id="custom-classification" name="input-type-text" type="text">
@@ -93,7 +93,7 @@ permalink: /enter-employee-details/
     </div>
   </fieldset>
   <div class="optional-info" data-height="270">
-    <a class="link_block add_overtime slide-down-handler">+ Add overtime</a>
+    <a class="link_block add_overtime slide-down-handler add-link">+ Add overtime</a>
     <div class="slide-down-content">
       <h5>Overtime</h5>
       <fieldset>
@@ -166,7 +166,7 @@ permalink: /enter-employee-details/
 
     <div class="optional-info" data-height="100">
       <label for="custom-classification" class="slide-down-handler">
-        <a id="add-classification">+ Add deduction</a>
+        <a class="add-link" id="add-classification">+ Add deduction</a>
       </label>
       <div class="slide-down-content">
         <div class="form-group-deductions">

--- a/pages/enter-employee-details.html
+++ b/pages/enter-employee-details.html
@@ -21,8 +21,8 @@ permalink: /enter-employee-details/
     <div id="rates-fringes" class="slide-down-content" data-height="100">
       <p>Davis-Bacon prevailing wage: <span class="text-emphasize" id="db-wage"></span></p>
       <ul>
-        <li><p>Hourly rate: <span class="text-emphasize" id="rate"></span></p></li>
-        <li><p>Fringes: <span class="text-emphasize" id="fringes"></span></p></li>
+        <li>Hourly rate: <span class="text-emphasize" id="rate"></span></li>
+        <li>Fringes: <span class="text-emphasize" id="fringes"></span></li>
       </ul>
     </div>
     <div class="optional-info" data-height="200">

--- a/pages/enter-employee-details.html
+++ b/pages/enter-employee-details.html
@@ -82,7 +82,7 @@ permalink: /enter-employee-details/
         <input aria-describedby="dobHint" class="usa-form-control" id="straight-rate" name="straight-rate" pattern="0?[1-9]|1[012]" type="number" min="1" max="8" value="">
         <p class="error-message"></p>
       </div>
-      <div class="form_group-rate-item form_group-rate-fringe">
+      <div class="form_group-rate-item form_group-rate-fringe form_group-rate-fringe-hourly">
         <label for="day_sunday" class="label-straight">Hourly fringe (cash)</label>
         <input aria-describedby="dobHint" class="usa-form-control" id="straight-fringe" name="straight-fringe" pattern="0?[1-9]|1[012]" type="number" min="1" max="8" value="">
       </div>


### PR DESCRIPTION
This styles the fringe page a bit:
- New error styling to closer match USWDS style https://standards.usa.gov/form-controls/#text-inputs 
- New error text from @acolter in #75. (would be nice if we could get the dollar amount in the message @hbillings.).
- Bringing hourly rate up one level so it's side-by-side with the total hours.
- Add pointer cursor on hover for JS links.

This is what it looks like:

Error message:

<img width="753" alt="screen shot 2016-05-04 at 12 12 12 pm" src="https://cloud.githubusercontent.com/assets/5249443/15026190/16623638-11f2-11e6-82bb-4ae53bd091a6.png">

Layout:

<img width="844" alt="screen shot 2016-05-04 at 11 54 00 am" src="https://cloud.githubusercontent.com/assets/5249443/15026228/41b5fd1a-11f2-11e6-8687-eb19f7cfb11e.png">
