### PR TITLE
Add icon to show third level subs

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -338,6 +338,10 @@ td input[type="checkbox"] + label {
   display: block;
 }
 
+.row-third-level {
+
+}
+
 // Upload payroll page ----- //
 
 .file_upload {

--- a/pages/prime/dashboard.html
+++ b/pages/prime/dashboard.html
@@ -149,7 +149,10 @@ permalink: /prime/welcome/
             </td>
           </tr>
           <tr class="row-sub">
-            <th scope="row">March 18, 2016</th>
+            <th scope="row">
+              <i class="fa fa-plus" aria-hidden="false"></i>
+              March 18, 2016
+            </th>
             <td>Dunder Mifflin</td>
             <td></td>
             <td>
@@ -241,7 +244,10 @@ permalink: /prime/welcome/
             </td>
           </tr>
           <tr class="row-sub">
-            <th scope="row">Not received</th>
+            <th scope="row">
+              <i class="fa fa-plus" aria-hidden="false"></i>
+              Not received
+            </th>
             <td>Wernham Hogg</td>
             <td></td>
             <td>


### PR DESCRIPTION
<img width="1021" alt="screen shot 2016-05-11 at 5 20 59 pm" src="https://cloud.githubusercontent.com/assets/5249443/15200587/fcb9c808-179c-11e6-8cff-65e9def1aa3c.png">

Starts to address #83.

Doesn't currently function, but you can begin to see how it would work.
