### PR TITLE
Expand horizontal space for table

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -588,6 +588,12 @@ table input[type="checkbox"] + label {
   overflow: hidden;
 }
 
+.review-hours-and-earnings {
+  .usa-grid {
+    max-width: 100%;
+  }
+}
+
 // Sign and certify page
 
 label[for="select-plans"] {


### PR DESCRIPTION
The table was too narrow for the review hours page, so this expands that page.
