### PR TITLE
Change "Ready to send" to "Received"

### DIFF
--- a/pages/prime/view-past-payrolls.html
+++ b/pages/prime/view-past-payrolls.html
@@ -54,7 +54,7 @@ permalink: /prime/past-payrolls/
       <select name="status" id="status" class="use-chosen">
         <option value="">All statuses</option>
         <option value="">Sent</option>
-        <option value="">Ready to send</option>
+        <option value="">Received</option>
         <option value="">Flagged</option>
         <option value="">Not received</option>
         <option value="">Delinquent</option>


### PR DESCRIPTION
OK so this is probably my first official pull request on an actual working repository, so please forgive if I'm doing this wrong. 

I thought that "Received" would be a better choice for payroll status than "Ready to send," because received covers the fact that you've got it, whether or not you've reviewed it yet. If you don't want to accept this change (or merge or whatever) no big deal.
